### PR TITLE
Add Missing token 'READ_WRITE' to keywordMap

### DIFF
--- a/a2l/matrix_dim.go
+++ b/a2l/matrix_dim.go
@@ -24,7 +24,7 @@ type MatrixDim struct {
 // this function is special because it is the only function that utilizes tokenizer.previous().
 // this is the case because matrixDim is not clearly defined in earlier a2l standards (e.g. 1.6.0).
 // therefore it is possible to describe a curve with "MATRIX_DIM 1" and "MATRIX_DIM 1 0 0".
-// so the parser checks whether the token is a keyword in which case it rolls back the tokenizer one value and exits
+// so the parser checks whether the token is a keyword or standalone keyword in which case it rolls back the tokenizer one value and exits
 // or if it finds a number that can be parsed.
 // if it could parse x, y and z dim it will exit normally.
 func parseMatrixDim(tok *tokenGenerator) (MatrixDim, error) {
@@ -40,6 +40,12 @@ forLoop:
 		} else if isKeyword(tok.current()) {
 			//see above comment
 			log.Info().Str("current token", tok.current()).Msg("matrixDim detected keyword:")
+			tok.previous()
+			log.Info().Str("previous token", tok.current()).Msg("matrixDim rolled back to:")
+			break forLoop
+		} else if isStandaloneKeyword(tok.current()) {
+			//see above comment
+			log.Info().Str("current token", tok.current()).Msg("matrixDim detected standalone keyword:")
 			tok.previous()
 			log.Info().Str("previous token", tok.current()).Msg("matrixDim rolled back to:")
 			break forLoop

--- a/a2l/token_generator.go
+++ b/a2l/token_generator.go
@@ -329,6 +329,13 @@ func isKeyword(str string) bool {
 	return exists
 }
 
+// isStandaloneKeyword is used only in the matrixDim to detected when there are no dimensions left to parse.
+// see isKeyword and tokens.go for more details.
+func isStandaloneKeyword(str string) bool {
+	_, exists := standaloneKeywordMap[str]
+	return exists
+}
+
 // getTwoWordedToken handles keywords that contain a / like e.g. "/begin CHARACTERISTIC"
 func getTwoWordedToken(currentOuterIndex *int, currentInnerIndex *int, str [][]string) (string, error) {
 	var err error

--- a/a2l/tokens.go
+++ b/a2l/tokens.go
@@ -617,4 +617,5 @@ var keywordMap = map[string]uint8{
 	"VAR_NAMING":                      0,
 	"VAR_SELECTION_CHARACTERISTIC":    0,
 	"VERSION":                         0,
+	"READ_WRITE":					   0,
 }

--- a/a2l/tokens.go
+++ b/a2l/tokens.go
@@ -617,5 +617,11 @@ var keywordMap = map[string]uint8{
 	"VAR_NAMING":                      0,
 	"VAR_SELECTION_CHARACTERISTIC":    0,
 	"VERSION":                         0,
-	"READ_WRITE":					   0,
+}
+
+var standaloneKeywordMap = map[string]uint8{
+	"READ_WRITE": 0,
+	"READ_ONLY": 0,
+	"DISCRETE": 0,
+	"VIRTUAL": 0,
 }


### PR DESCRIPTION
Added Missing Token "READ_WRITE" to keywordMap.

keywordMap is used by Parser for "MARTIX_DIM" to check if it is still parsing MatrixDim values.
